### PR TITLE
(Not well tested) open projects specified as NeoVim arguments

### DIFF
--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -58,7 +58,7 @@ M.setup = function(options)
 
   -- Don't load a session if nvim started with args, open just given files
   if vim.fn.argc() == 0 then
-    if path.cwd_matches_project() then
+    if path.dir_matches_project() then
       -- nvim started in the project dir, open current dir session
       start_session_here = true
     else

--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -69,6 +69,12 @@ M.setup = function(options)
     end
   end
 
+  local open_path = path.resolve("%:p")
+  if open_path ~= nil and path.dir_matches_project(open_path) then
+    vim.api.nvim_set_current_dir(open_path)
+    start_session_here = true
+  end
+
   M.options.session_manager_opts.sessions_dir = path.sessionspath
 
   -- Session Manager setup

--- a/lua/neovim-project/utils/path.lua
+++ b/lua/neovim-project/utils/path.lua
@@ -16,12 +16,12 @@ function M.init()
   M.homedir = vim.fn.expand("~")
 end
 
-M.cwd_matches_project = function()
+M.dir_matches_project = function(dir)
+  local dir_resolved = dir or M.resolve(M.cwd())
   -- Check if current working directory mathch project patterns
   local projects = M.get_all_projects()
-  local cwd_resolved = M.resolve(M.cwd())
   for _, path in ipairs(projects) do
-    if M.resolve(path) == cwd_resolved then
+    if M.resolve(path) == dir_resolved then
       M.dir_pretty = M.short_path(path) -- store path with user defined symlinks
       return true
     end


### PR DESCRIPTION
This is kind of hacky as it relies on NeoVim opening directories in a buffer as it would files(better than manually parsing the args though, imo), maybe it should just be its own plugin that changes the cwd to whatever the argument specified so it just triggers the "open cwd as project" part instead?