### PR TITLE
fix: exit from session if CWD changed from outside

### DIFF
--- a/lua/neovim-project/utils/path.lua
+++ b/lua/neovim-project/utils/path.lua
@@ -46,6 +46,7 @@ end
 
 M.short_path = function(path)
   -- Reduce file name to be relative to the home directory, if possible.
+  path = M.resolve(path)
   return vim.fn.fnamemodify(path, ":~")
 end
 


### PR DESCRIPTION
`:cd other-path` will disable saving the current session