### PR TITLE
fix: respect last_session_on_startup

### DIFF
--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -69,10 +69,12 @@ M.setup = function(options)
     end
   end
 
-  local open_path = path.resolve("%:p")
-  if open_path ~= nil and path.dir_matches_project(open_path) then
-    vim.api.nvim_set_current_dir(open_path)
-    start_session_here = true
+  if M.options.last_session_on_startup then
+    local open_path = path.resolve("%:p")
+    if open_path ~= nil and path.dir_matches_project(open_path) then
+      vim.api.nvim_set_current_dir(open_path)
+      start_session_here = true
+    end
   end
 
   M.options.session_manager_opts.sessions_dir = path.sessionspath

--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -57,7 +57,7 @@ M.setup = function(options)
   M.options.session_manager_opts.autoload_mode = AutoLoadMode.Disabled
 
   -- Don't load a session if nvim started with args, open just given files
-  if vim.fn.argc() == 0 then
+  if vim.fn.argc() == 0 and M.options.last_session_on_startup then
     local cmd = require("neovim-project.utils.cmd")
     local is_man = cmd.check_open_cmd("+Man!")
 
@@ -65,10 +65,7 @@ M.setup = function(options)
       -- nvim started in the project dir, open current dir session
       start_session_here = true
     else
-      -- Open the recent session if not disabled from config
-      if M.options.last_session_on_startup then
-        M.options.session_manager_opts.autoload_mode = AutoLoadMode.LastSession
-      end
+      M.options.session_manager_opts.autoload_mode = AutoLoadMode.LastSession
     end
   end
 


### PR DESCRIPTION
When nvim is opened in a project directory or when nvim has a project directory as an argument, last_session_on_startup = false is ignored and the associated project (session) is restored. 

This change respects the setting so the session not restored. 