### PR TITLE
feat: allow use different pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🗃️ Neovim project manager plugin
 
-**Neovim project** plugin simplifies project management by maintaining project history and providing quick access to saved sessions via [Telescope](https://github.com/nvim-telescope/telescope.nvim). It runs on top of the [Neovim Session Manager](https://github.com/Shatur/neovim-session-manager), which is needed to store all open tabs and buffers for each project.
+**Neovim project** plugin simplifies project management by maintaining project history and providing quick access to saved sessions via [Telescope](https://github.com/nvim-telescope/telescope.nvim) or [fzf-lua](https://github.com/ibhagwan/fzf-lua). It runs on top of the [Neovim Session Manager](https://github.com/Shatur/neovim-session-manager), which is needed to store all open tabs and buffers for each project.
 
 - ✅ Start where you left off last time.
 - ✅ Switch from project to project in second.
@@ -21,7 +21,7 @@
 3. Open files inside the project and work.
 4. The session will be saved before closing Neovim or switching to another project via [commands](#commands).
 5. Open Neovim in any non-project directory and the latest session will be loaded.
-   
+
 ## 📦 Installation
 
 You can install the plugin using your preferred package manager.
@@ -36,6 +36,9 @@ You can install the plugin using your preferred package manager.
       "~/projects/*",
       "~/.config/*",
     },
+    picker = {
+      type = "telescope", -- or "fzf-lua", "builtin"
+    }
   },
   init = function()
     -- enable saving the state of plugins in the session
@@ -43,7 +46,10 @@ You can install the plugin using your preferred package manager.
   end,
   dependencies = {
     { "nvim-lua/plenary.nvim" },
+    -- optional picker
     { "nvim-telescope/telescope.nvim", tag = "0.1.4" },
+    -- optional picker
+    { "ibhagwan/fzf-lua" },
     { "Shatur/neovim-session-manager" },
   },
   lazy = false,
@@ -67,11 +73,17 @@ use({
         "~/projects/*",
         "~/.config/*",
       },
+      picker = {
+        type = "telescope", -- or "fzf-lua", "builtin"
+      }
     }
   end,
   requires = {
     { "nvim-lua/plenary.nvim" },
+    -- optional picker
     { "nvim-telescope/telescope.nvim", tag = "0.1.4" },
+    -- optional picker
+    { "ibhagwan/fzf-lua" },
     { "Shatur/neovim-session-manager" },
   }
 })
@@ -93,11 +105,17 @@ use({
         "~/projects/*",
         "~/.config/*",
       },
+      picker = {
+        type = "telescope", -- or "fzf-lua", "builtin"
+      }
     }
   end,
   requires = {
     { "nvim-lua/plenary.nvim" },
+    -- optional picker
     { "nvim-telescope/telescope.nvim", tag = "0.1.4" },
+    -- optional picker
+    { "ibhagwan/fzf-lua" },
     { "Shatur/neovim-session-manager" },
   }
 };
@@ -145,6 +163,15 @@ use({
       "toggleterm",
     },
   },
+  -- Picker to use for project selection
+  -- Options: "builtin", "telescope", "fzf-lua"
+  -- Default to builtin if not specified or if the specified picker is not available
+  picker = {
+    type = "builtin", -- or "fzf-lua", "telescope"
+    opts = {
+      -- picker-specific options
+    },
+  },
 }
 ```
 
@@ -152,9 +179,9 @@ use({
 
 Neovim project manager will add these commands:
 
-- `:Telescope neovim-project discover` - find a project based on patterns.
+- `:NeovimProjectDiscover` - find a project based on patterns.
 
-- `:Telescope neovim-project history` - select a project from your recent history.
+- `:NeovimProjectHistory` - select a project from your recent history.
 
 - `:NeovimProjectLoadRecent` - open the previous session.
 
@@ -164,13 +191,15 @@ Neovim project manager will add these commands:
 
 History is sorted by access time. "Discover" keeps order as you have in the config.
 
-#### Telescope mappings
+#### Mappings
 
-Use `Ctrl+d` in Telescope to delete the project's session and remove it from the history.
+Use `Ctrl+d` in Telescope / fzf-lua to delete the project's session and remove it from the history.
 
 ## ⚡ Requirements
 
 - Neovim >= 0.8.0
+- Optional: Telescope.nvim for the Telescope picker
+- Optional: fzf-lua for the fzf-lua picker
 
 ## Demo video
 
@@ -186,7 +215,6 @@ So when you need to edit Neovim config, you open project `~/.config/nvim` by typ
 Of course, you want to use vim-fugitive and gitsigns in these projects. And it should be a single git repo for dotfiles. By default, Neovim will know nothing about your dotfiles repo.
 
 Create autocommands to update env variables to tell Neovim where is your dotfiles bare repo. Here is an example from my dotfiles:
-
 
 ```lua
 local augroup = vim.api.nvim_create_augroup("user_cmds", { clear = true })

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can install the plugin using your preferred package manager.
       "~/.config/*",
     },
     picker = {
-      type = "telescope", -- or "fzf-lua", "builtin"
+      type = "telescope", -- or "fzf-lua"
     }
   },
   init = function()
@@ -74,7 +74,7 @@ use({
         "~/.config/*",
       },
       picker = {
-        type = "telescope", -- or "fzf-lua", "builtin"
+        type = "telescope", -- or "fzf-lua"
       }
     }
   end,
@@ -106,7 +106,7 @@ use({
         "~/.config/*",
       },
       picker = {
-        type = "telescope", -- or "fzf-lua", "builtin"
+        type = "telescope", -- or "fzf-lua"
       }
     }
   end,
@@ -164,10 +164,10 @@ use({
     },
   },
   -- Picker to use for project selection
-  -- Options: "builtin", "telescope", "fzf-lua"
-  -- Default to builtin if not specified or if the specified picker is not available
+  -- Options: telescope", "fzf-lua"
+  -- Default to builtin select ui if not specified or if the specified picker is not available
   picker = {
-    type = "builtin", -- or "fzf-lua", "telescope"
+    type = "telescope", -- or "fzf-lua"
     opts = {
       -- picker-specific options
     },

--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -57,7 +57,7 @@ Lazy.nvim ~
           "~/.config/*",
         },
         picker = {
-          type = "telescope", -- or "fzf-lua", "builtin"
+          type = "telescope", -- or "fzf-lua"
         }
       },
       init = function()
@@ -92,7 +92,7 @@ packer.nvim ~
             "~/.config/*",
           },
           picker = {
-            type = "telescope", -- or "fzf-lua", "builtin"
+            type = "telescope", -- or "fzf-lua"
           }
         }
       end,
@@ -122,7 +122,7 @@ pckr.nvim ~
             "~/.config/*",
           },
           picker = {
-            type = "telescope", -- or "fzf-lua", "builtin"
+            type = "telescope", -- or "fzf-lua"
           }
         }
       end,
@@ -179,11 +179,11 @@ DEFAULT OPTIONS: ~
           "toggleterm",
         },
       },
-  -- Picker to use for project selection
-      -- Options: "builtin", "telescope", "fzf-lua"
-      -- Default to builtin if not specified or if the specified picker is not available
+      -- Picker to use for project selection
+      -- Options: telescope", "fzf-lua"
+      -- Default to builtin select ui if not specified or if the specified picker is not available
       picker = {
-        type = "builtin", -- or "telescope", "fzf-lua"
+        type = "telescope", -- or "fzf-lua"
         opts = {
           -- picker-specific options
         },

--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -18,7 +18,8 @@ Table of Contents                           *neovim-project-table-of-contents*
 
 **Neovim project** plugin simplifies project management by maintaining project
 history and providing quick access to saved sessions via Telescope
-<https://github.com/nvim-telescope/telescope.nvim>. It runs on top of the
+<https://github.com/nvim-telescope/telescope.nvim> or fzf-lua
+<https://github.com/ibhagwan/fzf-lua>. It runs on top of the
 Neovim Session Manager <https://github.com/Shatur/neovim-session-manager>,
 which is needed to store all open tabs and buffers for each project.
 
@@ -55,6 +56,9 @@ Lazy.nvim ~
           "~/projects/*",
           "~/.config/*",
         },
+        picker = {
+          type = "telescope", -- or "fzf-lua", "builtin"
+        }
       },
       init = function()
         -- enable saving the state of plugins in the session
@@ -62,7 +66,10 @@ Lazy.nvim ~
       end,
       dependencies = {
         { "nvim-lua/plenary.nvim" },
+        -- optional picker
         { "nvim-telescope/telescope.nvim", tag = "0.1.4" },
+        -- optional picker
+        { "ibhagwan/fzf-lua" },
         { "Shatur/neovim-session-manager" },
       },
       lazy = false,
@@ -84,11 +91,17 @@ packer.nvim ~
             "~/projects/*",
             "~/.config/*",
           },
+          picker = {
+            type = "telescope", -- or "fzf-lua", "builtin"
+          }
         }
       end,
       requires = {
         { "nvim-lua/plenary.nvim" },
+        -- optional picker
         { "nvim-telescope/telescope.nvim", tag = "0.1.4" },
+        -- optional picker
+        { "ibhagwan/fzf-lua" },
         { "Shatur/neovim-session-manager" },
       }
     })
@@ -108,11 +121,17 @@ pckr.nvim ~
             "~/projects/*",
             "~/.config/*",
           },
+          picker = {
+            type = "telescope", -- or "fzf-lua", "builtin"
+          }
         }
       end,
       requires = {
         { "nvim-lua/plenary.nvim" },
+        -- optional picker
         { "nvim-telescope/telescope.nvim", tag = "0.1.4" },
+        -- optional picker
+        { "ibhagwan/fzf-lua" },
         { "Shatur/neovim-session-manager" },
       }
     };
@@ -160,6 +179,15 @@ DEFAULT OPTIONS: ~
           "toggleterm",
         },
       },
+  -- Picker to use for project selection
+      -- Options: "builtin", "telescope", "fzf-lua"
+      -- Default to builtin if not specified or if the specified picker is not available
+      picker = {
+        type = "builtin", -- or "telescope", "fzf-lua"
+        opts = {
+          -- picker-specific options
+        },
+      },
     }
 <
 
@@ -168,25 +196,24 @@ COMMANDS       *neovim-project-🗃️-neovim-project-manager-plugin-commands*
 
 Neovim project manager will add these commands:
 
-- `:Telescope neovim-project discover` - find a project based on patterns.
-- `:Telescope neovim-project history` - select a project from your recent history.
+- `:NeovimProjectDiscover` - find a project based on patterns.
+- `:NeovimProjectHistory` - select a project from your recent history using the configured picker.
 - `:NeovimProjectLoadRecent` - open the previous session.
-- `:NeovimProjectLoadHist` - opens the project from the history providing a project dir.
-- `:NeovimProjectLoad` - opens the project from all your projects providing a project dir.
+- `:NeovimProjectLoadHist` - opens the project from the history using the configured picker.
+- `:NeovimProjectLoad` - opens the project from all your projects using the configured picker.
 
 History is sorted by access time. "Discover" keeps order as you have in the
 config.
 
+MAPPINGS
 
-TELESCOPE MAPPINGS
-
-Use `Ctrl+d` in Telescope to delete the project’s session and remove it from
-the history.
-
+Use `Ctrl+d` in Telescope / fzf-lua to delete the project's session and remove it from the history.
 
 ⚡ REQUIREMENTS*neovim-project-🗃️-neovim-project-manager-plugin-⚡-requirements*
 
 - Neovim >= 0.8.0
+- Optional: Telescope.nvim for the Telescope picker
+- Optional: fzf-lua for the fzf-lua picker
 
 
 DEMO VIDEO   *neovim-project-🗃️-neovim-project-manager-plugin-demo-video*

--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -40,6 +40,16 @@ M.defaults = {
     autosave_only_in_session = true,
     autosave_ignore_not_normal = false,
   },
+
+  -- Picker to use for project selection
+  -- Options: "builtin", "telescope", "fzf-lua"
+  -- Default to builtin if not specified or if the specified picker is not available
+  picker = {
+    type = "builtin", -- or "fzf-lua", "telescope"
+    opts = {
+      -- picker-specific options
+    },
+  },
 }
 
 ---@type ProjectOptions
@@ -68,7 +78,7 @@ M.setup = function(options)
     local is_man = cmd.check_open_cmd("+Man!")
 
     if
-      not is_man and (path.chdir_closest_parent_project() or path.chdir_closest_parent_project(path.resolve("%:p")))
+        not is_man and (path.chdir_closest_parent_project() or path.chdir_closest_parent_project(path.resolve("%:p")))
     then
       -- nvim started in the project dir or sub project , open current dir session
       start_session_here = true
@@ -84,9 +94,6 @@ M.setup = function(options)
 
   -- Session Manager setup
   require("session_manager").setup(M.options.session_manager_opts)
-
-  -- Register Telescope extension
-  require("telescope").load_extension("neovim-project")
 
   -- unset session_manager_opts
   ---@diagnostic disable-next-line: inject-field

--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -42,10 +42,10 @@ M.defaults = {
   },
 
   -- Picker to use for project selection
-  -- Options: "builtin", "telescope", "fzf-lua"
-  -- Default to builtin if not specified or if the specified picker is not available
+  -- Options: telescope", "fzf-lua"
+  -- Default to builtin select ui if not specified or if the specified picker is not available
   picker = {
-    type = "builtin", -- or "fzf-lua", "telescope"
+    type = "telescope", -- or "fzf-lua"
     opts = {
       -- picker-specific options
     },

--- a/lua/neovim-project/picker.lua
+++ b/lua/neovim-project/picker.lua
@@ -1,0 +1,148 @@
+local M = {}
+local config = require("neovim-project.config")
+local path = require("neovim-project.utils.path")
+local history = require("neovim-project.utils.history")
+
+function M.create_picker(opts, discover, callback, delete_session_func)
+    local picker = config.options.picker.type
+    local picker_opts = vim.tbl_deep_extend("force", config.options.picker.opts or {}, opts or {})
+
+    if picker == "telescope" and pcall(require, "telescope") then
+        return M.create_telescope_picker(picker_opts, discover)
+    elseif picker == "fzf-lua" and pcall(require, "fzf-lua") then
+        return M.create_fzf_lua_picker(picker_opts, discover, callback, delete_session_func)
+    else
+        return M.create_builtin_picker(picker_opts, discover, callback, delete_session_func)
+    end
+end
+
+function M.create_telescope_picker(opts, discover)
+    local telescope = require("telescope")
+    if discover then
+        return telescope.extensions["neovim-project"].discover(opts)
+    else
+        return telescope.extensions["neovim-project"].history(opts)
+    end
+end
+
+function M.create_fzf_lua_picker(opts, discover, callback, delete_session_func)
+    local fzf = require("fzf-lua")
+
+    local results
+    if discover then
+        results = path.get_all_projects()
+    else
+        results = history.get_recent_projects()
+        results = path.fix_symlinks_for_history(results)
+        -- Reverse results
+        for i = 1, math.floor(#results / 2) do
+            results[i], results[#results - i + 1] = results[#results - i + 1], results[i]
+        end
+    end
+
+    local function format_entry(entry)
+        local name = vim.fn.fnamemodify(entry, ":t")
+        return string.format("%s\t%s", name, entry)
+    end
+
+    local formatted_results = vim.tbl_map(format_entry, results)
+
+    -- Default options
+    local default_opts = {
+        prompt = discover and "Discover Projects> " or "Recent Projects> ",
+        actions = {
+            ["default"] = function(selected)
+                if selected and #selected > 0 then
+                    local dir = selected[1]:match("\t(.+)$")
+                    callback(dir)
+                end
+            end,
+            ["ctrl-d"] = function(selected)
+                if selected and #selected > 0 then
+                    local dir = selected[1]:match("\t(.+)$")
+                    local choice = vim.fn.confirm("Delete '" .. dir .. "' from project list?", "&Yes\n&No", 2)
+                    if choice == 1 then
+                        history.delete_project(dir)
+                        delete_session_func(dir)
+                        -- Refresh the picker
+                        M.create_fzf_lua_picker(opts, discover, callback, delete_session_func)
+                    end
+                end
+            end,
+        },
+        fzf_opts = {
+            ["--delimiter"] = "\t",
+            ["--with-nth"] = "1",
+            ["--preview"] = "echo {}",
+            ["--preview-window"] = "hidden:right:0",
+        },
+    }
+
+    local merged_opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+
+    fzf.fzf_exec(formatted_results, merged_opts)
+end
+
+function M.create_builtin_picker(opts, discover, callback, delete_session_func)
+    local results
+    if discover then
+        results = path.get_all_projects()
+    else
+        results = history.get_recent_projects()
+        results = path.fix_symlinks_for_history(results)
+        -- Reverse results
+        for i = 1, math.floor(#results / 2) do
+            results[i], results[#results - i + 1] = results[#results - i + 1], results[i]
+        end
+    end
+
+    local default_opts = {
+        prompt = discover and "Discover Projects" or "Recent Projects",
+        format_item = function(item)
+            return vim.fn.fnamemodify(item, ":t") .. " (" .. item .. ")"
+        end,
+    }
+
+    local merged_opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+
+    local function select_project()
+        vim.ui.select(results, merged_opts, function(choice)
+            if choice then
+                callback(choice)
+            end
+        end)
+    end
+
+    local function delete_project()
+        vim.ui.select(results, {
+            prompt = "Select project to delete",
+            format_item = merged_opts.format_item,
+        }, function(choice)
+            if choice then
+                local confirm = vim.fn.confirm("Delete '" .. choice .. "' from project list?", "&Yes\n&No", 2)
+                if confirm == 1 then
+                    history.delete_project(choice)
+                    delete_session_func(choice)
+                    -- Refresh the picker
+                    M.create_builtin_picker(opts, discover, callback, delete_session_func)
+                else
+                    -- Go back to project selection
+                    select_project()
+                end
+            end
+        end)
+    end
+
+    -- Add an option to delete projects
+    vim.ui.select({ "Select Project", "Delete Project" }, {
+        prompt = "Choose an action",
+    }, function(choice)
+        if choice == "Select Project" then
+            select_project()
+        elseif choice == "Delete Project" then
+            delete_project()
+        end
+    end)
+end
+
+return M

--- a/lua/neovim-project/picker.lua
+++ b/lua/neovim-project/picker.lua
@@ -4,145 +4,145 @@ local path = require("neovim-project.utils.path")
 local history = require("neovim-project.utils.history")
 
 function M.create_picker(opts, discover, callback, delete_session_func)
-    local picker = config.options.picker.type
-    local picker_opts = vim.tbl_deep_extend("force", config.options.picker.opts or {}, opts or {})
+  local picker = config.options.picker.type
+  local picker_opts = vim.tbl_deep_extend("force", config.options.picker.opts or {}, opts or {})
 
-    if picker == "telescope" and pcall(require, "telescope") then
-        return M.create_telescope_picker(picker_opts, discover)
-    elseif picker == "fzf-lua" and pcall(require, "fzf-lua") then
-        return M.create_fzf_lua_picker(picker_opts, discover, callback, delete_session_func)
-    else
-        return M.create_builtin_picker(picker_opts, discover, callback, delete_session_func)
-    end
+  if picker == "telescope" and pcall(require, "telescope") then
+    return M.create_telescope_picker(picker_opts, discover)
+  elseif picker == "fzf-lua" and pcall(require, "fzf-lua") then
+    return M.create_fzf_lua_picker(picker_opts, discover, callback, delete_session_func)
+  else
+    return M.create_builtin_picker(picker_opts, discover, callback, delete_session_func)
+  end
 end
 
 function M.create_telescope_picker(opts, discover)
-    local telescope = require("telescope")
-    if discover then
-        return telescope.extensions["neovim-project"].discover(opts)
-    else
-        return telescope.extensions["neovim-project"].history(opts)
-    end
+  local telescope = require("telescope")
+  if discover then
+    return telescope.extensions["neovim-project"].discover(opts)
+  else
+    return telescope.extensions["neovim-project"].history(opts)
+  end
 end
 
 function M.create_fzf_lua_picker(opts, discover, callback, delete_session_func)
-    local fzf = require("fzf-lua")
+  local fzf = require("fzf-lua")
 
-    local results
-    if discover then
-        results = path.get_all_projects()
-    else
-        results = history.get_recent_projects()
-        results = path.fix_symlinks_for_history(results)
-        -- Reverse results
-        for i = 1, math.floor(#results / 2) do
-            results[i], results[#results - i + 1] = results[#results - i + 1], results[i]
+  local results
+  if discover then
+    results = path.get_all_projects()
+  else
+    results = history.get_recent_projects()
+    results = path.fix_symlinks_for_history(results)
+    -- Reverse results
+    for i = 1, math.floor(#results / 2) do
+      results[i], results[#results - i + 1] = results[#results - i + 1], results[i]
+    end
+  end
+
+  local function format_entry(entry)
+    local name = vim.fn.fnamemodify(entry, ":t")
+    return string.format("%s\t%s", name, entry)
+  end
+
+  local formatted_results = vim.tbl_map(format_entry, results)
+
+  -- Default options
+  local default_opts = {
+    prompt = discover and "Discover Projects> " or "Recent Projects> ",
+    actions = {
+      ["default"] = function(selected)
+        if selected and #selected > 0 then
+          local dir = selected[1]:match("\t(.+)$")
+          callback(dir)
         end
-    end
+      end,
+      ["ctrl-d"] = function(selected)
+        if selected and #selected > 0 then
+          local dir = selected[1]:match("\t(.+)$")
+          local choice = vim.fn.confirm("Delete '" .. dir .. "' from project list?", "&Yes\n&No", 2)
+          if choice == 1 then
+            history.delete_project(dir)
+            delete_session_func(dir)
+            -- Refresh the picker
+            M.create_fzf_lua_picker(opts, discover, callback, delete_session_func)
+          end
+        end
+      end,
+    },
+    fzf_opts = {
+      ["--delimiter"] = "\t",
+      ["--with-nth"] = "1",
+      ["--preview"] = "echo {}",
+      ["--preview-window"] = "hidden:right:0",
+    },
+  }
 
-    local function format_entry(entry)
-        local name = vim.fn.fnamemodify(entry, ":t")
-        return string.format("%s\t%s", name, entry)
-    end
+  local merged_opts = vim.tbl_deep_extend("force", default_opts, opts or {})
 
-    local formatted_results = vim.tbl_map(format_entry, results)
-
-    -- Default options
-    local default_opts = {
-        prompt = discover and "Discover Projects> " or "Recent Projects> ",
-        actions = {
-            ["default"] = function(selected)
-                if selected and #selected > 0 then
-                    local dir = selected[1]:match("\t(.+)$")
-                    callback(dir)
-                end
-            end,
-            ["ctrl-d"] = function(selected)
-                if selected and #selected > 0 then
-                    local dir = selected[1]:match("\t(.+)$")
-                    local choice = vim.fn.confirm("Delete '" .. dir .. "' from project list?", "&Yes\n&No", 2)
-                    if choice == 1 then
-                        history.delete_project(dir)
-                        delete_session_func(dir)
-                        -- Refresh the picker
-                        M.create_fzf_lua_picker(opts, discover, callback, delete_session_func)
-                    end
-                end
-            end,
-        },
-        fzf_opts = {
-            ["--delimiter"] = "\t",
-            ["--with-nth"] = "1",
-            ["--preview"] = "echo {}",
-            ["--preview-window"] = "hidden:right:0",
-        },
-    }
-
-    local merged_opts = vim.tbl_deep_extend("force", default_opts, opts or {})
-
-    fzf.fzf_exec(formatted_results, merged_opts)
+  fzf.fzf_exec(formatted_results, merged_opts)
 end
 
 function M.create_builtin_picker(opts, discover, callback, delete_session_func)
-    local results
-    if discover then
-        results = path.get_all_projects()
-    else
-        results = history.get_recent_projects()
-        results = path.fix_symlinks_for_history(results)
-        -- Reverse results
-        for i = 1, math.floor(#results / 2) do
-            results[i], results[#results - i + 1] = results[#results - i + 1], results[i]
-        end
+  local results
+  if discover then
+    results = path.get_all_projects()
+  else
+    results = history.get_recent_projects()
+    results = path.fix_symlinks_for_history(results)
+    -- Reverse results
+    for i = 1, math.floor(#results / 2) do
+      results[i], results[#results - i + 1] = results[#results - i + 1], results[i]
     end
+  end
 
-    local default_opts = {
-        prompt = discover and "Discover Projects" or "Recent Projects",
-        format_item = function(item)
-            return vim.fn.fnamemodify(item, ":t") .. " (" .. item .. ")"
-        end,
-    }
+  local default_opts = {
+    prompt = discover and "Discover Projects" or "Recent Projects",
+    format_item = function(item)
+      return vim.fn.fnamemodify(item, ":t") .. " (" .. item .. ")"
+    end,
+  }
 
-    local merged_opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+  local merged_opts = vim.tbl_deep_extend("force", default_opts, opts or {})
 
-    local function select_project()
-        vim.ui.select(results, merged_opts, function(choice)
-            if choice then
-                callback(choice)
-            end
-        end)
-    end
-
-    local function delete_project()
-        vim.ui.select(results, {
-            prompt = "Select project to delete",
-            format_item = merged_opts.format_item,
-        }, function(choice)
-            if choice then
-                local confirm = vim.fn.confirm("Delete '" .. choice .. "' from project list?", "&Yes\n&No", 2)
-                if confirm == 1 then
-                    history.delete_project(choice)
-                    delete_session_func(choice)
-                    -- Refresh the picker
-                    M.create_builtin_picker(opts, discover, callback, delete_session_func)
-                else
-                    -- Go back to project selection
-                    select_project()
-                end
-            end
-        end)
-    end
-
-    -- Add an option to delete projects
-    vim.ui.select({ "Select Project", "Delete Project" }, {
-        prompt = "Choose an action",
-    }, function(choice)
-        if choice == "Select Project" then
-            select_project()
-        elseif choice == "Delete Project" then
-            delete_project()
-        end
+  local function select_project()
+    vim.ui.select(results, merged_opts, function(choice)
+      if choice then
+        callback(choice)
+      end
     end)
+  end
+
+  local function delete_project()
+    vim.ui.select(results, {
+      prompt = "Select project to delete",
+      format_item = merged_opts.format_item,
+    }, function(choice)
+      if choice then
+        local confirm = vim.fn.confirm("Delete '" .. choice .. "' from project list?", "&Yes\n&No", 2)
+        if confirm == 1 then
+          history.delete_project(choice)
+          delete_session_func(choice)
+          -- Refresh the picker
+          M.create_builtin_picker(opts, discover, callback, delete_session_func)
+        else
+          -- Go back to project selection
+          select_project()
+        end
+      end
+    end)
+  end
+
+  -- Add an option to delete projects
+  vim.ui.select({ "Select Project", "Delete Project" }, {
+    prompt = "Choose an action",
+  }, function(choice)
+    if choice == "Select Project" then
+      select_project()
+    elseif choice == "Delete Project" then
+      delete_project()
+    end
+  end)
 end
 
 return M

--- a/lua/neovim-project/project.lua
+++ b/lua/neovim-project/project.lua
@@ -6,6 +6,7 @@ local path = require("neovim-project.utils.path")
 local payload = require("neovim-project.payload")
 local utils = require("session_manager.utils")
 local config = require("neovim-project.config")
+local picker = require("neovim-project.picker")
 
 M.save_project_waiting = false
 
@@ -97,6 +98,18 @@ M.setup_autocmds = function()
       end
     end,
   })
+end
+
+local function switch_project_callback(dir)
+  M.switch_project(dir)
+end
+
+function M.show_history()
+  picker.create_picker({}, false, switch_project_callback, M.delete_session)
+end
+
+function M.discover_projects()
+  picker.create_picker({}, true, switch_project_callback, M.delete_session)
 end
 
 M.delete_session = function(dir)
@@ -246,6 +259,14 @@ M.create_commands = function()
       return projects
     end,
   })
+
+  vim.api.nvim_create_user_command("NeovimProjectHistory", function(args)
+    picker.create_picker(args, false, M.switch_project)
+  end, {})
+
+  vim.api.nvim_create_user_command("NeovimProjectDiscover", function(args)
+    picker.create_picker(args, true, M.switch_project)
+  end, {})
 end
 
 M.switch_project = function(dir)


### PR DESCRIPTION
This commit allows users to freely use the picker they want to use.

The default picker will utilize the builtin function `vim.ui.select`.

The following two commands have been changed to `NeovimProjectDiscover` and `NeovimProjectHistory`.

```
:Telescope neovim-project discover - find a project based on patterns.

:Telescope neovim-project history - select a project from your recent history.
```

Close #42 