### PR TITLE
feat: add command to select from both recent and all projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Neovim project manager will add these commands:
 
 - `:NeovimProjectHistory` - select a project from your recent history.
 
+- `:NeovimProjectAllHistory` - select a project based on patterns and recent history.
+
 - `:NeovimProjectLoadRecent` - open the previous session.
 
 - `:NeovimProjectLoadHist` - opens the project from the history providing a project dir.

--- a/lua/neovim-project/picker.lua
+++ b/lua/neovim-project/picker.lua
@@ -32,23 +32,7 @@ function M.create_fzf_lua_picker(opts, discover, callback, delete_session_func)
 
   local results
   if discover == "all_history" then
-    local recent = history.get_recent_projects()
-    recent = path.fix_symlinks_for_history(recent)
-
-    -- Reverse projects
-    for i = 1, math.floor(#recent / 2) do
-      recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
-    end
-
-    -- Add all projects and prioritise history
-    local seen = {}
-    results = {}
-    for _, proj in ipairs(vim.list_extend(recent, path.get_all_projects())) do
-      if not seen[proj] then
-        table.insert(results, proj)
-        seen[proj] = true
-      end
-    end
+    results = history.get_all_history()
   elseif discover then
     results = path.get_all_projects()
   else
@@ -106,23 +90,7 @@ end
 function M.create_builtin_picker(opts, discover, callback, delete_session_func)
   local results
   if discover == "all_history" then
-    local recent = history.get_recent_projects()
-    recent = path.fix_symlinks_for_history(recent)
-
-    -- Reverse projects
-    for i = 1, math.floor(#recent / 2) do
-      recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
-    end
-
-    -- Add all projects and prioritise history
-    local seen = {}
-    results = {}
-    for _, proj in ipairs(vim.list_extend(recent, path.get_all_projects())) do
-      if not seen[proj] then
-        table.insert(results, proj)
-        seen[proj] = true
-      end
-    end
+    results = history.get_all_history()
   elseif discover then
     results = path.get_all_projects()
   else

--- a/lua/neovim-project/picker.lua
+++ b/lua/neovim-project/picker.lua
@@ -31,7 +31,25 @@ function M.create_fzf_lua_picker(opts, discover, callback, delete_session_func)
   local fzf = require("fzf-lua")
 
   local results
-  if discover then
+  if discover == "all_history" then
+    local recent = history.get_recent_projects()
+    recent = path.fix_symlinks_for_history(recent)
+
+    -- Reverse projects
+    for i = 1, math.floor(#recent / 2) do
+      recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
+    end
+
+    -- Add all projects and prioritise history
+    local seen = {}
+    results = {}
+    for _, proj in ipairs(vim.list_extend(recent, path.get_all_projects())) do
+      if not seen[proj] then
+        table.insert(results, proj)
+        seen[proj] = true
+      end
+    end
+  elseif discover then
     results = path.get_all_projects()
   else
     results = history.get_recent_projects()
@@ -87,7 +105,25 @@ end
 
 function M.create_builtin_picker(opts, discover, callback, delete_session_func)
   local results
-  if discover then
+  if discover == "all_history" then
+    local recent = history.get_recent_projects()
+    recent = path.fix_symlinks_for_history(recent)
+
+    -- Reverse projects
+    for i = 1, math.floor(#recent / 2) do
+      recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
+    end
+
+    -- Add all projects and prioritise history
+    local seen = {}
+    results = {}
+    for _, proj in ipairs(vim.list_extend(recent, path.get_all_projects())) do
+      if not seen[proj] then
+        table.insert(results, proj)
+        seen[proj] = true
+      end
+    end
+  elseif discover then
     results = path.get_all_projects()
   else
     results = history.get_recent_projects()

--- a/lua/neovim-project/picker.lua
+++ b/lua/neovim-project/picker.lua
@@ -18,7 +18,9 @@ end
 
 function M.create_telescope_picker(opts, discover)
   local telescope = require("telescope")
-  if discover then
+  if discover == "all_history" then
+    return telescope.extensions["neovim-project"].all_history(opts)
+  elseif discover then
     return telescope.extensions["neovim-project"].discover(opts)
   else
     return telescope.extensions["neovim-project"].history(opts)

--- a/lua/neovim-project/project.lua
+++ b/lua/neovim-project/project.lua
@@ -260,6 +260,10 @@ M.create_commands = function()
     end,
   })
 
+  vim.api.nvim_create_user_command("NeovimProjectAllHistory", function(args)
+    picker.create_picker(args, "all_history", M.switch_project)
+  end, {})
+
   vim.api.nvim_create_user_command("NeovimProjectHistory", function(args)
     picker.create_picker(args, false, M.switch_project)
   end, {})

--- a/lua/neovim-project/utils/history.lua
+++ b/lua/neovim-project/utils/history.lua
@@ -116,6 +116,28 @@ function M.get_recent_projects()
   return sanitize_projects()
 end
 
+function M.get_all_history()
+  local recent = M.get_recent_projects()
+  recent = path.fix_symlinks_for_history(recent)
+
+  -- Reverse projects
+  for i = 1, math.floor(#recent / 2) do
+    recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
+  end
+
+  -- Add all projects and prioritise history
+  local seen = {}
+  local results = {}
+  for _, proj in ipairs(vim.list_extend(recent, path.get_all_projects())) do
+    if not seen[proj] then
+      table.insert(results, proj)
+      seen[proj] = true
+    end
+  end
+
+  return results
+end
+
 function M.make_sure_read_projects_from_history()
   if M.history_read == false then
     M.read_projects_from_history()

--- a/lua/telescope/_extensions/neovim-project.lua
+++ b/lua/telescope/_extensions/neovim-project.lua
@@ -22,7 +22,6 @@ local project = require("neovim-project.project")
 local function create_finder(discover)
   local results
   if discover == "all_history" then
-    local seen = {}
     local recent = history.get_recent_projects()
     recent = path.fix_symlinks_for_history(recent)
 
@@ -31,21 +30,13 @@ local function create_finder(discover)
       recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
     end
 
-    -- Add recent projects first
+    local seen = {}
     results = {}
-    for _, proj in ipairs(recent) do
-      if not seen[proj] then
-        table.insert(results, proj)
-        seen[proj] = true
-      end
-    end
-
-    -- Add all projects, ensuring no duplicates
-    for _, proj in ipairs(path.get_all_projects()) do
-      if not seen[proj] then
-        table.insert(results, proj)
-        seen[proj] = true
-     end
+    for _, proj in ipairs(vim.list_extend(recent, path.get_all_projects())) do
+        if not seen[proj] then
+            table.insert(results, proj)
+            seen[proj] = true
+        end
     end
   elseif discover then
     results = path.get_all_projects()

--- a/lua/telescope/_extensions/neovim-project.lua
+++ b/lua/telescope/_extensions/neovim-project.lua
@@ -30,13 +30,14 @@ local function create_finder(discover)
       recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
     end
 
+    -- Add all projects and prioritise history
     local seen = {}
     results = {}
     for _, proj in ipairs(vim.list_extend(recent, path.get_all_projects())) do
-        if not seen[proj] then
-            table.insert(results, proj)
-            seen[proj] = true
-        end
+      if not seen[proj] then
+        table.insert(results, proj)
+        seen[proj] = true
+      end
     end
   elseif discover then
     results = path.get_all_projects()

--- a/lua/telescope/_extensions/neovim-project.lua
+++ b/lua/telescope/_extensions/neovim-project.lua
@@ -22,23 +22,7 @@ local project = require("neovim-project.project")
 local function create_finder(discover)
   local results
   if discover == "all_history" then
-    local recent = history.get_recent_projects()
-    recent = path.fix_symlinks_for_history(recent)
-
-    -- Reverse projects
-    for i = 1, math.floor(#recent / 2) do
-      recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
-    end
-
-    -- Add all projects and prioritise history
-    local seen = {}
-    results = {}
-    for _, proj in ipairs(vim.list_extend(recent, path.get_all_projects())) do
-      if not seen[proj] then
-        table.insert(results, proj)
-        seen[proj] = true
-      end
-    end
+    results = history.get_all_history()
   elseif discover then
     results = path.get_all_projects()
   else


### PR DESCRIPTION
This PR introduces a new command (`:NeovimProjectAllHistory`) that combines both recent projects and all projects into a single unified list, that works for all supported pickers.

Which ensures recent projects appear first, followed by all projects, with duplicates removed.

```
:NeovimProjectAllHistory - select a project based on patterns and recent history.
```

