### PR TITLE
feat: allow Discover command to sort by history or alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,11 @@ use({
 
 Neovim project manager will add these commands:
 
-- `:NeovimProjectDiscover` - find a project based on patterns.
+- `:NeovimProjectDiscover [sort]` - find a project based on patterns, with optional sorting arguments:
+  - `default` (or no argument) - uses the order specified in the config.
+  - `history` - prioritises the most recently accessed projects.
+  - `alphabetical_name` - sorts projects alphabetically by project name.
+  - `alphabetical_path` - sorts projects alphabetically by their full path.
 
 - `:NeovimProjectHistory` - select a project from your recent history.
 
@@ -197,7 +201,7 @@ Neovim project manager will add these commands:
 
 - `:NeovimProjectLoad` - opens the project from all your projects providing a project dir.
 
-History is sorted by access time. "Discover" keeps order as you have in the config, if `history` is provided as an extra argument it will prioritise the most recent projects first.
+History is sorted by access time. "Discover" keeps order as you have in the config, but can be overridden using the sorting options.
 
 #### Mappings
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Neovim project manager will add these commands:
 
 - `:NeovimProjectLoad` - opens the project from all your projects providing a project dir.
 
-History is sorted by access time. "Discover" keeps order as you have in the config.
+History is sorted by access time. "Discover" keeps order as you have in the config, if `history` is provided as an extra argument it will prioritise the most recent projects first.
 
 #### Mappings
 

--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -210,7 +210,8 @@ Neovim project manager will add these commands:
 - `:NeovimProjectLoad` - opens the project from all your projects using the configured picker.
 
 History is sorted by access time. "Discover" keeps order as you have in the
-config.
+config, if `history` is provided as an extra argument it will prioritise
+the most recent projects first.
 
 MAPPINGS
 

--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -1,4 +1,4 @@
-*neovim-project.txt*             For              Last change: 2025 February 3
+*neovim-project.txt*             For              Last change: 2025 February 22
 
 ==============================================================================
 Table of Contents                           *neovim-project-table-of-contents*
@@ -203,15 +203,18 @@ COMMANDS       *neovim-project-🗃️-neovim-project-manager-plugin-commands*
 
 Neovim project manager will add these commands:
 
-- `:NeovimProjectDiscover` - find a project based on patterns.
+- `:NeovimProjectDiscover [sort]` - find a project based on patterns, with optional sorting arguments:
+  - `default` (or no argument) - uses the order specified in the config.
+  - `history` - prioritises the most recently accessed projects.
+  - `alphabetical_name` - sorts projects alphabetically by project name.
+  - `alphabetical_path` - sorts projects alphabetically by their full path.
 - `:NeovimProjectHistory` - select a project from your recent history using the configured picker.
 - `:NeovimProjectLoadRecent` - open the previous session.
 - `:NeovimProjectLoadHist` - opens the project from the history using the configured picker.
 - `:NeovimProjectLoad` - opens the project from all your projects using the configured picker.
 
 History is sorted by access time. "Discover" keeps order as you have in the
-config, if `history` is provided as an extra argument it will prioritise
-the most recent projects first.
+config, but can be overridden using the sorting options.
 
 MAPPINGS
 

--- a/lua/neovim-project/picker.lua
+++ b/lua/neovim-project/picker.lua
@@ -30,7 +30,7 @@ function M.create_fzf_lua_picker(opts, discover, callback, delete_session_func)
 
   local results
   if discover then
-    results = path.get_all_projects()
+    results = path.get_all_projects_with_sorting()
   else
     results = history.get_recent_projects()
     results = path.fix_symlinks_for_history(results)
@@ -86,7 +86,7 @@ end
 function M.create_builtin_picker(opts, discover, callback, delete_session_func)
   local results
   if discover then
-    results = path.get_all_projects()
+    results = path.get_all_projects_with_sorting()
   else
     results = history.get_recent_projects()
     results = path.fix_symlinks_for_history(results)

--- a/lua/neovim-project/project.lua
+++ b/lua/neovim-project/project.lua
@@ -265,8 +265,15 @@ M.create_commands = function()
   end, {})
 
   vim.api.nvim_create_user_command("NeovimProjectDiscover", function(args)
+    -- Default sorting to be alphabetical ascending
+    config.options.picker.opts.sorting = args.args or "alphabetical"
     picker.create_picker(args, true, M.switch_project)
-  end, {})
+    end, {
+      nargs = "?",
+      complete = function()
+        return { "alphabetical", "history" }
+    end,
+  })
 end
 
 M.switch_project = function(dir)

--- a/lua/neovim-project/project.lua
+++ b/lua/neovim-project/project.lua
@@ -265,13 +265,13 @@ M.create_commands = function()
   end, {})
 
   vim.api.nvim_create_user_command("NeovimProjectDiscover", function(args)
-    -- Default sorting to be alphabetical ascending
-    config.options.picker.opts.sorting = args.args or "alphabetical"
+    -- Default sorting based on patterns
+    config.options.picker.opts.sorting = args.args or "default"
     picker.create_picker(args, true, M.switch_project)
     end, {
       nargs = "?",
       complete = function()
-        return { "alphabetical", "history" }
+        return { "default", "history", "alphabetical_name", "alphabetical_path" }
     end,
   })
 end

--- a/lua/neovim-project/utils/path.lua
+++ b/lua/neovim-project/utils/path.lua
@@ -70,6 +70,36 @@ M.get_all_projects = function()
   return projects
 end
 
+M.get_all_projects_with_sorting = function()
+  -- Get all projects but with specific sorting
+  local sorting = require("neovim-project.config").options.picker.opts.sorting
+
+  -- Sort by most recent projects first
+  if sorting == "history" then
+    local recent = require("neovim-project.utils.history").get_recent_projects()
+    recent = M.fix_symlinks_for_history(recent)
+
+    -- Reverse projects
+    for i = 1, math.floor(#recent / 2) do
+      recent[i], recent[#recent - i + 1] = recent[#recent - i + 1], recent[i]
+    end
+
+    -- Add all projects and prioritise history
+    local seen, projects = {}, {}
+    for _, project in ipairs(vim.list_extend(recent, M.get_all_projects())) do
+      if not seen[project] then
+        table.insert(projects, project)
+        seen[project] = true
+      end
+    end
+    return projects
+
+  -- Default sort alphabetically
+  else
+    return M.get_all_projects()
+  end
+end
+
 M.short_path = function(path)
   -- Reduce file name to be relative to the home directory, if possible.
   path = M.resolve(path)

--- a/lua/neovim-project/utils/path.lua
+++ b/lua/neovim-project/utils/path.lua
@@ -73,6 +73,7 @@ end
 M.get_all_projects_with_sorting = function()
   -- Get all projects but with specific sorting
   local sorting = require("neovim-project.config").options.picker.opts.sorting
+  local all_projects = M.get_all_projects()
 
   -- Sort by most recent projects first
   if sorting == "history" then
@@ -86,7 +87,7 @@ M.get_all_projects_with_sorting = function()
 
     -- Add all projects and prioritise history
     local seen, projects = {}, {}
-    for _, project in ipairs(vim.list_extend(recent, M.get_all_projects())) do
+    for _, project in ipairs(vim.list_extend(recent, all_projects)) do
       if not seen[project] then
         table.insert(projects, project)
         seen[project] = true
@@ -94,9 +95,23 @@ M.get_all_projects_with_sorting = function()
     end
     return projects
 
-  -- Default sort alphabetically
+  -- Sort alphabetically ascending by project name
+  elseif sorting == "alphabetical_name" then
+    table.sort(all_projects, function(a, b)
+      local name_a = a:match(".*/([^/]+)$") or a
+      local name_b = b:match(".*/([^/]+)$") or b
+      return name_a:lower() < name_b:lower()
+    end)
+    return all_projects
+
+  -- Sort alphabetically ascending by project path
+  elseif sorting == "alphabetical_path" then
+    table.sort(all_projects)
+    return all_projects
+
+  -- Default sort based on patterns
   else
-    return M.get_all_projects()
+    return all_projects
   end
 end
 

--- a/lua/telescope/_extensions/neovim-project.lua
+++ b/lua/telescope/_extensions/neovim-project.lua
@@ -22,7 +22,7 @@ local project = require("neovim-project.project")
 local function create_finder(discover)
   local results
   if discover then
-    results = path.get_all_projects()
+    results = path.get_all_projects_with_sorting()
   else
     results = history.get_recent_projects()
     results = path.fix_symlinks_for_history(results)


### PR DESCRIPTION
### Summary

This PR adds an extra optional parameter to the `:NeovimProjectDiscover` command that allows you to change the ordering of the projects. Namely, two new parameters:
- `alphabetical` - default view (doesn't need to be passed in)
- `history` - prioritises most recent projects first, then all other discovered projects are added in after (alphabetically)

**Example:**
```
:NeovimProjectDiscover history
```

### Why

Wanted a way to be able to see all the projects from my directories, but still have the most recent projects show up first - mainly to have one command that could easily be used.