### PR TITLE
feat: git status in telescope preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,11 @@ use({
   -- Fallback to builtin select ui if the specified picker is not available
   picker = {
     type = "telescope", -- or "fzf-lua"
-    preview = true, -- show directory structure preview in Telescope
+    preview = {
+      enabled = true, -- show directory structure in Telescope preview
+      git_status = true, -- show branch name, an ahead/behind counter, and the git status of each file/folder
+      show_hidden = true, -- show hidden files/folders
+    },
     opts = {
       -- picker-specific options
     },

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ You can install the plugin using your preferred package manager.
     },
     picker = {
       type = "telescope", -- or "fzf-lua"
-      preview = true, -- show directory structure preview in Telescope
     }
   },
   init = function()
@@ -79,7 +78,6 @@ use({
       },
       picker = {
         type = "telescope", -- or "fzf-lua"
-        preview = true, -- show directory structure preview in Telescope
       }
     }
   end,
@@ -112,7 +110,6 @@ use({
       },
       picker = {
         type = "telescope", -- or "fzf-lua"
-        preview = true, -- show directory structure preview in Telescope
       }
     }
   end,

--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -194,7 +194,11 @@ DEFAULT OPTIONS: ~
       -- Fallback to builtin select ui if the specified picker is not available
       picker = {
         type = "telescope", -- or "fzf-lua"
-        preview = true, -- show directory structure preview in telescope
+	preview = {
+	  enabled = true, -- show directory structure in Telescope preview
+	  git_status = true, -- show branch name and the git status of each file/folder
+	  show_hidden = true, -- show hidden files/folders
+	},
         opts = {
           -- picker-specific options
         },

--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -58,11 +58,11 @@ Lazy.nvim ~
         },
         picker = {
           type = "telescope", -- or "fzf-lua"
-	  preview = {
-	    enabled = true, -- show directory structure in Telescope preview
-	    git_status = true, -- show branch name and the git status of each file/folder
-	    show_hidden = true, -- show hidden files/folders
-	  },
+          preview = {
+            enabled = true, -- show directory structure in Telescope preview
+            git_status = true, -- show branch name and the git status of each file/folder
+            show_hidden = true, -- show hidden files/folders
+          },
         }
       },
       init = function()
@@ -98,11 +98,11 @@ packer.nvim ~
           },
           picker = {
             type = "telescope", -- or "fzf-lua"
-	    preview = {
-	      enabled = true, -- show directory structure in Telescope preview
-	      git_status = true, -- show branch name and the git status of each file/folder
-	      show_hidden = true, -- show hidden files/folders
-	    },
+            preview = {
+              enabled = true, -- show directory structure in Telescope preview
+              git_status = true, -- show branch name and the git status of each file/folder
+              show_hidden = true, -- show hidden files/folders
+            },
           }
         }
       end,
@@ -133,11 +133,11 @@ pckr.nvim ~
           },
           picker = {
             type = "telescope", -- or "fzf-lua"
-	    preview = {
-	      enabled = true, -- show directory structure in Telescope preview
-	      git_status = true, -- show branch name and the git status of each file/folder
-	      show_hidden = true, -- show hidden files/folders
-	    },
+            preview = {
+              enabled = true, -- show directory structure in Telescope preview
+              git_status = true, -- show branch name and the git status of each file/folder
+              show_hidden = true, -- show hidden files/folders
+            },
           }
         }
       end,
@@ -206,11 +206,11 @@ DEFAULT OPTIONS: ~
       -- Fallback to builtin select ui if the specified picker is not available
       picker = {
         type = "telescope", -- or "fzf-lua"
-	preview = {
-	  enabled = true, -- show directory structure in Telescope preview
-	  git_status = true, -- show branch name and the git status of each file/folder
-	  show_hidden = true, -- show hidden files/folders
-	},
+        preview = {
+          enabled = true, -- show directory structure in Telescope preview
+          git_status = true, -- show branch name and the git status of each file/folder
+          show_hidden = true, -- show hidden files/folders
+        },
         opts = {
           -- picker-specific options
         },

--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -58,7 +58,11 @@ Lazy.nvim ~
         },
         picker = {
           type = "telescope", -- or "fzf-lua"
-          preview = true, -- show directory structure preview in telescope
+	  preview = {
+	    enabled = true, -- show directory structure in Telescope preview
+	    git_status = true, -- show branch name and the git status of each file/folder
+	    show_hidden = true, -- show hidden files/folders
+	  },
         }
       },
       init = function()
@@ -94,7 +98,11 @@ packer.nvim ~
           },
           picker = {
             type = "telescope", -- or "fzf-lua"
-            preview = true, -- show directory structure preview in telescope
+	    preview = {
+	      enabled = true, -- show directory structure in Telescope preview
+	      git_status = true, -- show branch name and the git status of each file/folder
+	      show_hidden = true, -- show hidden files/folders
+	    },
           }
         }
       end,
@@ -125,7 +133,11 @@ pckr.nvim ~
           },
           picker = {
             type = "telescope", -- or "fzf-lua"
-            preview = true, -- show directory structure preview in telescope
+	    preview = {
+	      enabled = true, -- show directory structure in Telescope preview
+	      git_status = true, -- show branch name and the git status of each file/folder
+	      show_hidden = true, -- show hidden files/folders
+	    },
           }
         }
       end,

--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -54,7 +54,7 @@ M.defaults = {
   picker = {
     type = "telescope", -- or "fzf-lua"
     preview = {
-      enabled = false, -- show directory structure preview in Telescope
+      enabled = true, -- show directory structure in Telescope preview
       git_status = true, -- show branch name and the git status of each file/folder
       show_hidden = true, -- show hidden files/folders
     },

--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -53,7 +53,11 @@ M.defaults = {
   -- Fallback to builtin select ui if the specified picker is not available
   picker = {
     type = "telescope", -- or "fzf-lua"
-    preview = true, -- show directory structure preview in Telescope
+    preview = {
+      enabled = false, -- show directory structure preview in Telescope
+      git_status = true, -- show branch name and the git status of each file/folder
+      show_hidden = true, -- show hidden files/folders
+    },
     opts = {
       -- picker-specific options
     },

--- a/lua/neovim-project/preview.lua
+++ b/lua/neovim-project/preview.lua
@@ -211,11 +211,6 @@ local function get_git_info(project_path)
           -- Clear preview cache to refresh the ahead/behind counts
           preview_cache[project_path] = nil
           fetched[project_path] = true
-
-          -- These commands are idempotent, it is harmless to spam them
-          -- They enable maintenance and fsmonitor, optimizations that speed up fetch and status commands on large repos, and are harmless on small ones
-          vim.fn.system("git -C config core.fsmonitor builtin")
-          vim.fn.system("git -C maintenance start")
         end,
       })
     end

--- a/lua/neovim-project/preview.lua
+++ b/lua/neovim-project/preview.lua
@@ -166,7 +166,7 @@ M.project_previewer = previewers.new_buffer_previewer({
     if preview_cache[project_path] then
       render_preview()
     else
-      self._preview_timer:start(33, 0, vim.schedule_wrap(render_preview))
+      self._preview_timer:start(50, 0, vim.schedule_wrap(render_preview))
     end
   end,
 })

--- a/lua/neovim-project/preview.lua
+++ b/lua/neovim-project/preview.lua
@@ -206,7 +206,7 @@ local function get_git_info(project_path)
     if not fetched[project_path] then
       local fetch_job_id = vim.fn.jobstart("git fetch --quiet", {
         cwd = project_path,
-        detach = true,
+        detach = false,
         on_exit = function(_, _, _)
           -- Clear preview cache to refresh the ahead/behind counts
           preview_cache[project_path] = nil

--- a/lua/neovim-project/preview.lua
+++ b/lua/neovim-project/preview.lua
@@ -2,6 +2,12 @@ local M = {}
 
 local previewers = require("telescope.previewers")
 
+local initialized = false
+
+M.init = function()
+  M.define_preview_highlighting()
+end
+
 --- Stolen from oil.nvim
 --- Check for an icon provider and return a common icon provider API
 M.get_icon_provider = function()
@@ -10,7 +16,7 @@ M.get_icon_provider = function()
   ---@diagnostic disable-next-line: undefined-field
   if _G.MiniIcons then -- `_G.MiniIcons` is a better check to see if the module is setup
     return function(type, name)
-      return mini_icons.get(type == "directory" and "directory" or "file", name)
+      return mini_icons.get(type, name)
     end
   end
 
@@ -40,6 +46,9 @@ M.project_previewer = previewers.new_buffer_previewer({
     return entry.value
   end,
   define_preview = function(self, entry)
+    if not initialized then
+      M.init()
+    end
     local project_path = entry.value
     local preview_data = M.generate_project_preview(project_path)
 
@@ -59,6 +68,173 @@ M.project_previewer = previewers.new_buffer_previewer({
     end
   end,
 })
+
+-- Get the current git branch and status for a project path
+function M.get_git_info(project_path)
+  local current_dir = vim.fn.getcwd()
+  local result = {
+    branch = "",
+    ahead = "",
+    behind = "",
+  }
+
+  vim.fn.chdir(project_path)
+
+  -- Get branch name
+  local branch_name = vim.fn.system("git branch --show-current 2>/dev/null"):gsub("\n", "")
+
+  -- Only proceed if we have a valid branch
+  if branch_name ~= "" then
+    result.branch = branch_name
+
+    -- Fetch from remote to get up-to-date information (optional, can be removed if too slow)
+    -- vim.fn.system("git fetch --quiet 2>/dev/null")
+
+    -- Get ahead/behind counts
+    local status_output = vim.fn.system(
+      "git rev-list --left-right --count origin/" .. branch_name .. "..." .. branch_name .. " 2>/dev/null"
+    )
+
+    -- Parse the output which is in format "N M" where N is behind and M is ahead
+    local behind, ahead = status_output:match("(%d+)%s+(%d+)")
+    behind = tonumber(behind)
+    ahead = tonumber(ahead)
+
+    if behind and behind > 0 then
+      result.behind = behind
+    end
+    if ahead and ahead > 0 then
+      result.ahead = ahead
+    end
+  end
+
+  vim.fn.chdir(current_dir)
+
+  return result
+end
+
+function M.define_preview_highlighting()
+  -- Basic UI elements
+  local normal_fg = vim.fn.synIDattr(vim.fn.hlID("Normal"), "fg#")
+  local normal_bg = vim.fn.synIDattr(vim.fn.hlID("Normal"), "bg#")
+  local cursor_line_bg = vim.fn.synIDattr(vim.fn.hlID("CursorLine"), "bg#")
+  local visual_bg = vim.fn.synIDattr(vim.fn.hlID("Visual"), "bg#")
+
+  -- Text elements
+  local comment_fg = vim.fn.synIDattr(vim.fn.hlID("Comment"), "fg#")
+  local string_fg = vim.fn.synIDattr(vim.fn.hlID("String"), "fg#")
+  local number_fg = vim.fn.synIDattr(vim.fn.hlID("Number"), "fg#")
+  local constant_fg = vim.fn.synIDattr(vim.fn.hlID("Constant"), "fg#")
+
+  -- Programming elements
+  local function_fg = vim.fn.synIDattr(vim.fn.hlID("Function"), "fg#")
+  local keyword_fg = vim.fn.synIDattr(vim.fn.hlID("Keyword"), "fg#")
+  local statement_fg = vim.fn.synIDattr(vim.fn.hlID("Statement"), "fg#")
+  local type_fg = vim.fn.synIDattr(vim.fn.hlID("Type"), "fg#")
+  local special_fg = vim.fn.synIDattr(vim.fn.hlID("Special"), "fg#")
+  local identifier_fg = vim.fn.synIDattr(vim.fn.hlID("Identifier"), "fg#")
+
+  -- UI elements
+  local pmenu_bg = vim.fn.synIDattr(vim.fn.hlID("Pmenu"), "bg#")
+  local pmenu_sel_bg = vim.fn.synIDattr(vim.fn.hlID("PmenuSel"), "bg#")
+  local error_fg = vim.fn.synIDattr(vim.fn.hlID("Error"), "fg#")
+  local warning_fg = vim.fn.synIDattr(vim.fn.hlID("WarningMsg"), "fg#")
+  local todo_fg = vim.fn.synIDattr(vim.fn.hlID("Todo"), "fg#")
+  local directory_fg = vim.fn.synIDattr(vim.fn.hlID("Directory"), "fg#")
+  local title_fg = vim.fn.synIDattr(vim.fn.hlID("Title"), "fg#")
+
+  -- Status line
+  local statusline_fg = vim.fn.synIDattr(vim.fn.hlID("StatusLine"), "fg#")
+  local statusline_bg = vim.fn.synIDattr(vim.fn.hlID("StatusLine"), "bg#")
+  local statusline_nc_bg = vim.fn.synIDattr(vim.fn.hlID("StatusLineNC"), "bg#")
+
+  -- Diff colors
+  local diff_add_bg = vim.fn.synIDattr(vim.fn.hlID("DiffAdd"), "bg#")
+  local diff_change_bg = vim.fn.synIDattr(vim.fn.hlID("DiffChange"), "bg#")
+  local diff_delete_bg = vim.fn.synIDattr(vim.fn.hlID("DiffDelete"), "bg#")
+  local diff_text_bg = vim.fn.synIDattr(vim.fn.hlID("DiffText"), "bg#")
+
+  local title_group = "NeovimProjectTitle"
+  local branch_group = "NeovimProjectBranch"
+  local sync_group = "NeovimProjectSync"
+
+  vim.api.nvim_set_hl(0, title_group, {
+    bg = title_fg,
+    fg = normal_bg,
+    bold = true,
+  })
+
+  vim.api.nvim_set_hl(0, branch_group, {
+    bg = function_fg,
+    fg = normal_bg,
+    bold = true,
+  })
+
+  vim.api.nvim_set_hl(0, sync_group, {
+    bg = cursor_line_bg,
+    fg = normal_fg,
+    bold = true,
+  })
+end
+
+-- Generate header for project preview
+function M.generate_preview_header(project_path)
+  local header = {}
+  local header_highlights = {}
+  local project_title = vim.fn.fnamemodify(project_path, ":t")
+  -- Add padding spaces for better appearance with background color
+
+  local branch_icon = M.icon_provider("filetype", "git", {
+    default_file = "",
+  })
+
+  local git_info = M.get_git_info(project_path)
+  local title_string = " " .. project_title .. " "
+  local branch_string = " " .. branch_icon .. " " .. git_info.branch .. " "
+  local sync_string = git_info.ahead .. " " .. git_info.behind
+  local formatted_header = title_string .. branch_string -- .. sync_string
+  table.insert(header, formatted_header)
+
+  local title_width = #title_string
+  local title_start = 0
+  local title_end = title_start + title_width
+
+  local branch_width = #branch_string
+  local branch_start = title_end
+  local branch_end = branch_start + branch_width
+
+  local sync_width = #sync_string
+  local sync_start = branch_end
+  local sync_end = sync_start + sync_width
+
+  table.insert(header_highlights, {
+    line = 0, -- 0-indexed line number
+    hl = "NeovimProjectTitle", -- Use our custom highlight group
+    start_col = title_start,
+    end_col = title_end,
+  })
+
+  table.insert(header_highlights, {
+    line = 0, -- 0-indexed line number
+    hl = "NeovimProjectBranch", -- Use our custom highlight group
+    start_col = branch_start,
+    end_col = branch_end,
+  })
+
+  table.insert(header_highlights, {
+    line = 0, -- 0-indexed line number
+    hl = "NeovimProjectSync", -- Use our custom highlight group
+    start_col = sync_start,
+    end_col = sync_end,
+  })
+  -- Add a separator line
+  -- table.insert(header, string.rep("─", 200))
+
+  -- -- Add a blank line for spacing
+  -- table.insert(header, "")
+
+  return { lines = header, highlights = header_highlights }
+end
 
 -- Generate project preview content
 function M.generate_project_preview(project_path)
@@ -93,15 +269,27 @@ function M.generate_project_preview(project_path)
     end
   end
 
-  -- Sort directories and files alphabetically
+  --  Sort directories and files alphabetically
   table.sort(directories)
   table.sort(files)
 
   local output = {}
   local highlights = {}
 
-  -- blank line for padding
-  table.insert(output, "")
+  -- -- blank line for padding
+  -- table.insert(output, "")
+  -- Get header content
+  local header = M.generate_preview_header(project_path)
+
+  -- Add header lines to output
+  for _, line in ipairs(header.lines) do
+    table.insert(output, line)
+  end
+
+  -- Add header highlights to highlights
+  for _, hl in ipairs(header.highlights) do
+    table.insert(highlights, hl)
+  end
 
   -- Helper function to format a file/folder and add it to the output
   local function process_item(item, is_directory)

--- a/lua/neovim-project/preview.lua
+++ b/lua/neovim-project/preview.lua
@@ -74,7 +74,7 @@ M.init = function()
     group = vim.api.nvim_create_augroup("NeovimProjectHighlights", { clear = true }),
   })
 
-  -- Set up an autocmd to clear currect project cache when opening the picker, this ensures that recent changes are visible
+  -- Set up an autocmd to clear current project cache when opening the picker, this ensures that recent changes are visible
   vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter" }, {
     callback = function()
       clear_caches()

--- a/lua/neovim-project/preview.lua
+++ b/lua/neovim-project/preview.lua
@@ -74,8 +74,8 @@ function M.get_git_info(project_path)
   local current_dir = vim.fn.getcwd()
   local result = {
     branch = "",
-    ahead = "",
-    behind = "",
+    ahead = 0,
+    behind = 0,
   }
 
   vim.fn.chdir(project_path)
@@ -97,15 +97,8 @@ function M.get_git_info(project_path)
 
     -- Parse the output which is in format "N M" where N is behind and M is ahead
     local behind, ahead = status_output:match("(%d+)%s+(%d+)")
-    behind = tonumber(behind)
-    ahead = tonumber(ahead)
-
-    if behind and behind > 0 then
-      result.behind = behind
-    end
-    if ahead and ahead > 0 then
-      result.ahead = ahead
-    end
+    result.behind = tonumber(behind)
+    result.ahead = tonumber(ahead)
   end
 
   vim.fn.chdir(current_dir)
@@ -171,8 +164,8 @@ function M.define_preview_highlighting()
   })
 
   vim.api.nvim_set_hl(0, sync_group, {
-    bg = cursor_line_bg,
-    fg = normal_fg,
+    bg = normal_bg,
+    fg = warning_fg,
     bold = true,
   })
 end
@@ -191,8 +184,17 @@ function M.generate_preview_header(project_path)
   local git_info = M.get_git_info(project_path)
   local title_string = " " .. project_title .. " "
   local branch_string = " " .. branch_icon .. " " .. git_info.branch .. " "
-  local sync_string = git_info.ahead .. " " .. git_info.behind
-  local formatted_header = title_string .. branch_string -- .. sync_string
+  local ahead = ""
+  local behind = ""
+  vim.notify(git_info.ahead .. ", " .. git_info.behind)
+  if git_info.ahead > 0 then
+    ahead = "↑" .. git_info.ahead
+  end
+  if git_info.behind > 0 then
+    behind = "↓" .. git_info.behind
+  end
+  local sync_string = " " .. behind .. ahead
+  local formatted_header = title_string .. branch_string .. sync_string
   table.insert(header, formatted_header)
 
   local title_width = #title_string

--- a/lua/neovim-project/utils/history.lua
+++ b/lua/neovim-project/utils/history.lua
@@ -116,6 +116,20 @@ function M.get_recent_projects()
   return sanitize_projects()
 end
 
+function M.get_current_project()
+  local projects = M.get_recent_projects()
+
+  if #M.session_projects > 0 then
+    return M.session_projects[#M.session_projects]
+  end
+
+  if projects and #projects > 0 then
+    return projects[#projects]
+  end
+
+  return ""
+end
+
 function M.make_sure_read_projects_from_history()
   if M.history_read == false then
     M.read_projects_from_history()

--- a/lua/telescope/_extensions/neovim-project.lua
+++ b/lua/telescope/_extensions/neovim-project.lua
@@ -16,7 +16,7 @@ local history = require("neovim-project.utils.history")
 local preview = require("neovim-project.preview")
 local project = require("neovim-project.project")
 
-local show_preview = require("neovim-project.config").options.picker.preview
+local show_preview = require("neovim-project.config").options.picker.preview.enabled
 
 ----------
 -- Actions


### PR DESCRIPTION
# Git Status Previews!
![image](https://github.com/user-attachments/assets/04ea4a9b-ede9-4e6d-a741-e9cb1fb17657)
This image pretty much shows off all of the features, I abused one of my repos so you could see all of the pretty colors.

List of changes:
- Added option to show hidden files in preview
- Added option to show git status info in preview
- Added header to preview. This includes the project title, current branch, and number of commits ahead and behind the origin
- Added status indicators to files, A, M, and D, for added, modified, and deleted
- Added lots of highlighting, should be compatible with any colorscheme
- Added a caching system for project previews, the picker was beginning to stutter from running git commands, still very usable without caching, but once the caching is done all hitches are eliminated
- Also added some debouncing to enable smooth key_repeat scrolling even without completed preview caching
- Now running git fetch asynchronously to get the current number of commits ahead and behind, you can find some comments that go more in depth on this
- Now running commands to enable maintenance and fsmonitor on all repos, this speeds up fetch and status on large repos and is harmless on small ones

##  Colorschemes
I think this looks best in my colorscheme of choice, github_dark_default, but I made an effort to pull colors from the current colorscheme, so it should work with anything. This seems to play nice with all of the themes installed on my system, but not all themes define the same highlight groups, so it's possible there are some out there that would have contrast issues.
#### default
![image](https://github.com/user-attachments/assets/feb57236-74fa-49e1-a887-fa7bb4e532df)
#### tokyonight-night
![image](https://github.com/user-attachments/assets/9ae69d1f-34fa-4fc1-b8d9-4d4ba852a668)
#### catppuccin-mocha
![image](https://github.com/user-attachments/assets/0a06da83-9e42-4d83-a3f9-115dbfba1038)
#### onedark (warmer)
![image](https://github.com/user-attachments/assets/15befd1b-4ac5-4dd1-94d3-636960642062)

This even works with hideous light themes

#### github-light-default
![image](https://github.com/user-attachments/assets/9659bbd8-b080-4ef5-81a4-f12404fdb1d0)
#### peachpuff
![image](https://github.com/user-attachments/assets/3705ae42-d5fe-4c31-b235-7dcc0816bd1b)


## Non-Repos
![image](https://github.com/user-attachments/assets/13011e5b-5291-43e5-ae1c-a779124c9a8c)
Project folders that aren't repos just appear as any project would with git_status set to false.