### PR TITLE
feat: add 'follow_symlinks' config option and support partial following

### DIFF
--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -167,6 +167,11 @@ DEFAULT OPTIONS: ~
         "~/.config/*",
         "~/work/*",
       },
+      -- Whether or not to follow symlinks in the project glob patterns
+      -- "full" or true - follow symlinks in all matched directories
+      -- "partial" - follow symlinks before any matching operators (*, ?, [])
+      -- "none" or false or nil - do not follow symlinks
+      follow_symlinks = true,
       -- Path to store history and sessions
       datapath = vim.fn.stdpath("data"), -- ~/.local/share/nvim/
       -- Load the most recent session on startup if not in the project directory

--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -10,6 +10,11 @@ M.defaults = {
     "~/.config/*",
     "~/work/*",
   },
+  -- Whether or not to follow symlinks in the project glob patterns
+  -- "full" or true - follow symlinks in all matched directories
+  -- "partial" - follow symlinks before any matching operators (*, ?, [])
+  -- "none" or false or nil - do not follow symlinks
+  follow_symlinks = "full",
   -- Path to store history and sessions
   datapath = vim.fn.stdpath("data"), -- ~/.local/share/nvim/
   -- Load the most recent session on startup if not in the project directory

--- a/lua/neovim-project/project.lua
+++ b/lua/neovim-project/project.lua
@@ -25,8 +25,6 @@ M.setup_autocmds = function()
     pattern = "*",
     group = augroup,
     callback = function()
-      path._VimLeavePre = true
-      path.write_persistent_cache()
       history.write_projects_to_history()
     end,
   })

--- a/lua/neovim-project/utils/path.lua
+++ b/lua/neovim-project/utils/path.lua
@@ -278,7 +278,7 @@ M.fix_symlinks_for_history = function(dirs)
   if follow_symlinks == true or follow_symlinks == "full" then
     local projects = M.get_all_projects()
     for i, dir in ipairs(dirs) do
-      local dir_resolved = M.resolve(dir)
+      local dir_resolved
       for _, path in ipairs(projects) do
         local path_resolved
         if dir_resolved == nil then
@@ -286,25 +286,25 @@ M.fix_symlinks_for_history = function(dirs)
             if path == dir then
               dirs[i] = path
               break
-            else
-              path_resolved = M.resolve(path)
-              if path_resolved == dir then
-                dirs[i] = path
-                break
-              end
             end
+            path_resolved = M.resolve(path)
           end
-          dir_resolved = M.resolve(dir)
-        else
-          if path_resolved == nil then
-            if path == dir_resolved then
-              dirs[i] = path
-              break
-            end
-          elseif path_resolved == dir_resolved then
+          if path_resolved == dir then
             dirs[i] = path
             break
           end
+          dir_resolved = M.resolve(dir)
+        end
+        if path_resolved == nil then
+          if path == dir_resolved then
+            dirs[i] = path
+            break
+          end
+          path_resolved = M.resolve(path)
+        end
+        if path_resolved == dir_resolved then
+          dirs[i] = path
+          break
         end
       end
     end


### PR DESCRIPTION
1. Add `follow_symlinks` configuration option. The default value is `"full"`.
2. With `follow_symlinks = "partial"`, `chdir_closest_parent_project` and `fix_symlinks_for_history` do not expand all the glob patterns. Instead, they tries to find out the glob pattern which best matches the given dir, and then do the remaining operations by expanding this pattern.
3. Caches of all projects list are removed.
4. Minor performance improvements by reducing calls to `M.resolve` and `M.short_path` in `fix_symlinks_for_history` and `is_subdirectory`.
5. The default option `follow_symlinks = "full"` ensures backwards compatibility.

`follow_symlinks = "partial"` reduces the startuptime by 10x on my machine.