### PR TITLE
feat: option for patterns to ignore projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ use({
     "~/.config/*",
     "~/work/*",
   },
+  -- Ignore directories
+  -- Useful if you have something like "~/projects/*.worktrees/*" in
+  -- projects and want to filter out the parent directory with
+  -- ignore_projects = { "~/projects/*.worktrees/" }
+  ignore_projects = {}
   -- Path to store history and sessions
   datapath = vim.fn.stdpath("data"), -- ~/.local/share/nvim/
   -- Load the most recent session on startup if not in the project directory

--- a/doc/neovim-project.txt
+++ b/doc/neovim-project.txt
@@ -160,6 +160,11 @@ DEFAULT OPTIONS: ~
         "~/.config/*",
         "~/work/*",
       },
+      -- Ignore directories
+      -- Useful if you have something like "~/projects/*.worktrees/*" in
+      -- projects and want to filter out the parent directory with
+      -- ignore_projects = { "~/projects/*.worktrees/" }
+      ignore_projects = {}
       -- Path to store history and sessions
       datapath = vim.fn.stdpath("data"), -- ~/.local/share/nvim/
       -- Load the most recent session on startup if not in the project directory

--- a/lua/neovim-project/config.lua
+++ b/lua/neovim-project/config.lua
@@ -10,6 +10,11 @@ M.defaults = {
     "~/.config/*",
     "~/work/*",
   },
+  -- Ignore directories
+  -- Useful if you have something like "~/projects/*.worktrees/*" in
+  -- projects and want to filter out the parent directory with
+  -- ignore_projects = { "~/projects/*.worktrees/" }
+  ignore_projects = {},
   -- Path to store history and sessions
   datapath = vim.fn.stdpath("data"), -- ~/.local/share/nvim/
   -- Load the most recent session on startup if not in the project directory

--- a/lua/neovim-project/utils/path.lua
+++ b/lua/neovim-project/utils/path.lua
@@ -141,17 +141,34 @@ M.get_all_projects = function(patterns)
   if patterns == nil then
     patterns = require("neovim-project.config").options.projects
   end
+
+  local ignore_patterns = require("neovim-project.config").options.ignore_projects or {}
+  local ignore_set = {}
+  for _, ignore_pattern in ipairs(ignore_patterns) do
+    local ignore_tbl = vim.fn.glob(ignore_pattern, true, true, true)
+    for _, ignore_path in ipairs(ignore_tbl) do
+      if vim.fn.isdirectory(ignore_path) == 1 then
+        ignore_set[M.resolve(ignore_path)] = true
+      end
+    end
+  end
+
   for _, pattern in ipairs(patterns) do
     local tbl = vim.fn.glob(pattern, true, true, true)
     for _, path in ipairs(tbl) do
       if vim.fn.isdirectory(path) == 1 then
-        local short = M.short_path(path)
-        if not vim.tbl_contains(projects, short) then
-          table.insert(projects, short)
+        local resolved = M.resolve(path)
+        local is_ignored = ignore_set[resolved] == true
+        if not is_ignored then
+          local short = M.short_path(path)
+          if not vim.tbl_contains(projects, short) then
+            table.insert(projects, short)
+          end
         end
       end
     end
   end
+
   return projects
 end
 


### PR DESCRIPTION
Adding `ignore_projects = {}` option. Here's some example use cases I had in mind for this feature:
```lua
projects = {
	"~/projects/*",
	"~/projects/*.worktrees/*",
	"~/projects/nvim-plugins/*",
},
ignore_projects = {
	"~/projects/*.worktrees/",
	"~/projects/nvim-plugins/",
},
```